### PR TITLE
Revert "support pessimistic transaction"

### DIFF
--- a/src/client/jTPCCConnection.java
+++ b/src/client/jTPCCConnection.java
@@ -232,8 +232,7 @@ public class jTPCCConnection
 		"SELECT no_o_id " +
 		"    FROM bmsql_new_order " +
 		"    WHERE no_w_id = ? AND no_d_id = ? " +
-		"    ORDER BY no_o_id ASC" +
-               "    FOR UPDATE");
+		"    ORDER BY no_o_id ASC");
 	stmtDeliveryBGDeleteOldestNewOrder = dbConn.prepareStatement(
 		"DELETE FROM bmsql_new_order " +
 		"    WHERE no_w_id = ? AND no_d_id = ? AND no_o_id = ?");


### PR DESCRIPTION
https://github.com/pingcap/benchmarksql/pull/3 will cause performance regression (13k -> 5k) based on our testing, we can use another branch for pessimistic txn.
PTAL @jackysp @youjiali1995 