### PR TITLE
support pessimistic transaction

### DIFF
--- a/src/client/jTPCCConnection.java
+++ b/src/client/jTPCCConnection.java
@@ -228,11 +228,13 @@ public class jTPCCConnection
 	}
 
 	// PreparedStatements for DELIVERY_BG
-	stmtDeliveryBGSelectOldestNewOrder = dbConn.prepareStatement(
-		"SELECT no_o_id " +
-		"    FROM bmsql_new_order " +
-		"    WHERE no_w_id = ? AND no_d_id = ? " +
-		"    ORDER BY no_o_id ASC");
+    stmtDeliveryBGSelectOldestNewOrder = dbConn.prepareStatement(
+        "SELECT no_o_id " +
+        "    FROM bmsql_new_order " +
+        "    WHERE no_w_id = ? AND no_d_id = ? " +
+        "    ORDER BY no_o_id ASC" +
+        "    LIMIT 1" +
+        "    FOR UPDATE");
 	stmtDeliveryBGDeleteOldestNewOrder = dbConn.prepareStatement(
 		"DELETE FROM bmsql_new_order " +
 		"    WHERE no_w_id = ? AND no_d_id = ? AND no_o_id = ?");


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

In `DeliveryBG`, it reads all orders first and then tries to delete the oldest order. It judges whether it deletes successfully or not by affected rows. So it requires the RC isolation level: https://github.com/pingcap/benchmarksql/blob/5.0-mysql-support-opt-2.1/src/client/jTPCCTData.java#L1627-L1635

In the optimistic transaction mode, the affected rows are not accurate and it always is 1.
In the pessimistic transaction mode, it reads from a snapshot but writes with the latest data. The affected rows maybe 0 which cause many loops.

For the optimistic transaction mode, the only influence of this PR is that it reads fewer data and writes a LOCK when commits.