### PR TITLE
optimize order status and stock level

### DIFF
--- a/run/sql.mysql/tableCreates.sql
+++ b/run/sql.mysql/tableCreates.sql
@@ -102,7 +102,7 @@ create table bmsql_order_line (
   ol_supply_w_id  integer,
   ol_quantity     integer,
   ol_dist_info    char(24),
-  constraint pk_order_line primary key (ol_w_id, ol_d_id, ol_o_id, ol_i_id)
+  constraint pk_order_line primary key (ol_w_id, ol_d_id, ol_o_id, ol_number)
 );
 
 create table bmsql_item (

--- a/run/sql.mysql/tableCreates.sql
+++ b/run/sql.mysql/tableCreates.sql
@@ -88,7 +88,7 @@ create table bmsql_oorder (
   o_all_local  integer,
   o_entry_d    timestamp,
   constraint pk_oorder primary key (o_w_id, o_d_id, o_id),
-  constraint bmsql_oorder_idx1 unique key (o_w_id, o_d_id, o_carrier_id, o_id)
+  constraint bmsql_oorder_idx1 unique key (o_w_id, o_d_id, o_c_id, o_id)
 );
 
 create table bmsql_order_line (
@@ -102,7 +102,7 @@ create table bmsql_order_line (
   ol_supply_w_id  integer,
   ol_quantity     integer,
   ol_dist_info    char(24),
-  constraint pk_order_line primary key (ol_w_id, ol_d_id, ol_o_id, ol_number)
+  constraint pk_order_line primary key (ol_w_id, ol_d_id, ol_o_id, ol_i_id, ol_number)
 );
 
 create table bmsql_item (

--- a/run/sql.mysql/tableCreates.sql
+++ b/run/sql.mysql/tableCreates.sql
@@ -102,7 +102,7 @@ create table bmsql_order_line (
   ol_supply_w_id  integer,
   ol_quantity     integer,
   ol_dist_info    char(24),
-  constraint pk_order_line primary key (ol_w_id, ol_d_id, ol_o_id, ol_i_id, ol_number)
+  constraint pk_order_line primary key (ol_w_id, ol_d_id, ol_o_id, ol_i_id)
 );
 
 create table bmsql_item (

--- a/src/client/jTPCCConnection.java
+++ b/src/client/jTPCCConnection.java
@@ -176,11 +176,7 @@ public class jTPCCConnection
 		"SELECT o_id, o_entry_d, o_carrier_id " +
 		"    FROM bmsql_oorder " +
 		"    WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ? " +
-		"      AND o_id = (" +
-		"          SELECT max(o_id) " +
-		"              FROM bmsql_oorder " +
-		"              WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ?" +
-		"          )");
+		"      ORDER BY o_id DESC LIMIT 1");
 	stmtOrderStatusSelectOrderLine = dbConn.prepareStatement(
 		"SELECT ol_i_id, ol_supply_w_id, ol_quantity, " +
 		"       ol_amount, ol_delivery_d " +

--- a/src/client/jTPCCTData.java
+++ b/src/client/jTPCCTData.java
@@ -1180,9 +1180,6 @@ log.trace("w_zip=" + payment.w_zip + " d_zip=" + payment.d_zip);
 	    stmt.setInt(1, orderStatus.w_id);
 	    stmt.setInt(2, orderStatus.d_id);
 	    stmt.setInt(3, orderStatus.c_id);
-	    stmt.setInt(4, orderStatus.w_id);
-	    stmt.setInt(5, orderStatus.d_id);
-	    stmt.setInt(6, orderStatus.c_id);
 	    rs = stmt.executeQuery();
 	    if (!rs.next())
 	    {


### PR DESCRIPTION
Utilize index for bmsql_oorder table.
- Change `o_carrier_id` to `o_c_id` in  `bmsql_oorder_idx1` for OrderStatus workload.
- Adding `ol_i_id` in `bmsql_order_line` table to reduce index lookup for StockLevel workload.