### PR TITLE
update jdbc configurations

### DIFF
--- a/run/props.mysql
+++ b/run/props.mysql
@@ -1,6 +1,6 @@
 db=mysql
 driver=com.mysql.jdbc.Driver
-conn=jdbc:mysql://localhost:4000/tpcc?useSSL=false&useServerPrepStmts=true&useConfigs=maxPerformance&rewriteBatchedStatements=true
+conn=jdbc:mysql://localhost:4000/tpcc?useSSL=false&useServerPrepStmts=true&useConfigs=maxPerformance&rewriteBatchedStatements=true&cachePrepStmts=true&prepStmtCacheSize=1000&prepStmtCacheSqlLimit=2048
 user=root
 password=
 


### PR DESCRIPTION
The following is a description of some parameter configurations related to caching prepared statement objects:

- cachePrepStmts=true: Enables caching of prepared statement objects on the client side to eliminate StmtPrepare and StmtClose calls, resulting in improved performance.
- prepStmtCacheSize: Must be configured to a value greater than 0. This value determines the maximum number of prepared statement objects in the cache. If this number is exceeded, the oldest object will be removed.
- prepStmtCacheSqlLimit: Must be set to a value greater than the length of the SQL text. If the length of the SQL statement exceeds this limit, it will not be cached.

The above configurations can improve the performance of database operations.