### PR TITLE
client: check connection status before rolling back transactions

### DIFF
--- a/src/client/jTPCCConnection.java
+++ b/src/client/jTPCCConnection.java
@@ -316,6 +316,8 @@ public class jTPCCConnection
     public void rollback()
 	throws SQLException
     {
+	if (!dbConn.isClosed()) {
 	dbConn.rollback();
+	}
     }
 }


### PR DESCRIPTION
TiDB will close connections when undetermined error occurs. It's better to check the connection status before handling errors.